### PR TITLE
Modify biblatex config to stick to UTBM ISO 690 interpretation

### DIFF
--- a/ISO690UTBM.dbx
+++ b/ISO690UTBM.dbx
@@ -1,0 +1,4 @@
+%Declare datamodel for consulté le
+\DeclareDatamodelFields[type=field,datatype=verbatim,nullok=true]{urldate}
+
+\DeclareDatamodelEntryfields{urldate}

--- a/ISO690UTBM.dbx
+++ b/ISO690UTBM.dbx
@@ -1,4 +1,4 @@
-%Declare datamodel for consulté le
+%Declare datamodel for consultation date
 \DeclareDatamodelFields[type=field,datatype=verbatim,nullok=true]{urldate}
 
 \DeclareDatamodelEntryfields{urldate}

--- a/biblatex.cfg
+++ b/biblatex.cfg
@@ -13,7 +13,7 @@
 
 \DeclareFieldFormat{title}{#1}%Remvoe italic title
 
-\renewbibmacro*{url+urldate}{% configure the urldate to be dispkayed after url fix
+\renewbibmacro*{url+urldate}{% configure the urldate to be displayed after url fix
   \printfield{url}%
   \newunit\newblock
   \printfield{urldate}%

--- a/biblatex.cfg
+++ b/biblatex.cfg
@@ -1,0 +1,20 @@
+%Configure biblatex to fit ISO-690 UTBM's takes
+%Expect biblatex style to be authortitle as iso-authoryear force italic for title
+\DefineBibliographyStrings{french}{% Define words to prefix url and urldate
+  urlseen = {consulté le},
+  urlfrom = {disponible sur},
+}
+
+\DeclareFieldFormat{urldate}{\mkbibparens{\bibstring{urlseen}\space#1}}% Add parenthethis insted of crochet for the consult date and add urlseen as prefix
+
+\DeclareFieldFormat{url}{\bibstring{urlfrom}\addcolon\space\url{#1}}% Format the URL to be prefixed by urlfrom
+
+\DeclareFieldFormat[online]{titleaddon}{\text{In : }\textit{#1}} % Italicize titleaddon aka website name and add In : prefix
+
+\DeclareFieldFormat{title}{#1}%Remvoe italic title
+
+\renewbibmacro*{url+urldate}{% configure the urldate to be dispkayed after url fix
+  \printfield{url}%
+  \newunit\newblock
+  \printfield{urldate}%
+}

--- a/biblatex.cfg
+++ b/biblatex.cfg
@@ -5,7 +5,7 @@
   urlfrom = {disponible sur},
 }
 
-\DeclareFieldFormat{urldate}{\mkbibparens{\bibstring{urlseen}\space#1}}% Add parenthethis insted of crochet for the consult date and add urlseen as prefix
+\DeclareFieldFormat{urldate}{\mkbibparens{\bibstring{urlseen}\space#1}}% Add round brackets instead of square brackets for the consulted date and add urlseen as prefix
 
 \DeclareFieldFormat{url}{\bibstring{urlfrom}\addcolon\space\url{#1}}% Format the URL to be prefixed by urlfrom
 

--- a/biblatex.cfg
+++ b/biblatex.cfg
@@ -9,7 +9,7 @@
 
 \DeclareFieldFormat{url}{\bibstring{urlfrom}\addcolon\space\url{#1}}% Format the URL to be prefixed by urlfrom
 
-\DeclareFieldFormat[online]{titleaddon}{\text{In : }\textit{#1}} % Italicize titleaddon aka website name and add In : prefix
+\DeclareFieldFormat[online]{titleaddon}{\text{In : }\textit{#1}} % Italicize titleaddon (aka website name) and add "In :" prefix
 
 \DeclareFieldFormat{title}{#1}%Remvoe italic title
 

--- a/biblatex.cfg
+++ b/biblatex.cfg
@@ -6,7 +6,7 @@
 }
 
 \DefineBibliographyStrings{english}{% Define words to prefix url and urldate
-urlseen = {last seen the},
+urlseen = {last seen on},
 urlfrom = {accessible on},
 }
 

--- a/biblatex.cfg
+++ b/biblatex.cfg
@@ -5,6 +5,11 @@
   urlfrom = {disponible sur},
 }
 
+\DefineBibliographyStrings{english}{% Define words to prefix url and urldate
+urlseen = {last seen the},
+urlfrom = {accessible on},
+}
+
 \DeclareFieldFormat{urldate}{\mkbibparens{\bibstring{urlseen}\space#1}}% Add round brackets instead of square brackets for the consulted date and add urlseen as prefix
 
 \DeclareFieldFormat{url}{\bibstring{urlfrom}\addcolon\space\url{#1}}% Format the URL to be prefixed by urlfrom

--- a/main.tex
+++ b/main.tex
@@ -12,7 +12,7 @@ style=authortitle,
 citestyle=verbose-ibid,
 abbreviate=false,
 language=french,
-datamodel=UtbmISOdatamodel]{biblatex} %ISO 690 Utbm
+datamodel=ISO690UTBM]{biblatex} %ISO 690 Utbm
 \input{biblatex.cfg} %Import biblatex config
 %----------------------------------------
 % Use Tahoma as base font

--- a/main.tex
+++ b/main.tex
@@ -7,8 +7,13 @@
 \usepackage{lipsum}
 \usepackage{sectsty}
 \usepackage{csquotes}
-\usepackage[style=ieee]{biblatex}
- 
+\usepackage[backend=biber,
+style=authortitle,
+citestyle=verbose-ibid,
+abbreviate=false,
+language=french,
+datamodel=UtbmISOdatamodel]{biblatex} %ISO 690 Utbm
+\input{biblatex.cfg} %Import biblatex config
 %----------------------------------------
 % Use Tahoma as base font
 %----------------------------------------


### PR DESCRIPTION
The goal of this pr is to modify the template to use ISO 690 for citation and bibliography 

- Add file biblatex.cfg containing commands to configure biblatex
- Add file ISO690UTBM.dbx to define new type to display consult date of cited website in the bibliography
- Modify main.tex to import those file and add flag to biblatex import